### PR TITLE
Fix outdated links in release package file

### DIFF
--- a/release/package_realtek.com_ameba_index.json
+++ b/release/package_realtek.com_ameba_index.json
@@ -531,14 +531,14 @@
             {
               "host": "i686-mingw32",
               "archiveFileName": "ameba_tools-1.0.8.tar.gz",
-              "url": "https://dl.dropboxusercontent.com/u/22098892/ameba_tools-1.0.8.tar.gz",
+	      "url": "https://github.com/Ameba8195/Arduino/raw/master/release/ameba-1.0.8.tar.gz",
               "checksum": "SHA-256:8f2f84ee52862c101e61e3eabae7f20384e02d8640451d96a5357fa260df82c7",
               "size": "5527556"
             },
             {
               "host": "x86_64-apple-darwin",
               "archiveFileName": "ameba_tools-1.0.8.tar.gz",
-              "url": "https://dl.dropboxusercontent.com/u/22098892/ameba_tools-1.0.8.tar.gz",
+	      "url": "https://github.com/Ameba8195/Arduino/raw/master/release/ameba-1.0.8.tar.gz",
               "checksum": "SHA-256:8f2f84ee52862c101e61e3eabae7f20384e02d8640451d96a5357fa260df82c7",
               "size": "5527556"
             }


### PR DESCRIPTION
The dropbox url seems outdated.
I still get "CRC doesn't match" when trying to install ameba 2.0.0 on osx ArduinoIDE 1.8.1